### PR TITLE
modify

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,6 @@ Usage
 
 .. code:: bash
 
-    $ thriftpy-cli -f thrift_file.thrift -h localhost -p 8010 -s ServiceName
+    $ thriftpy-cli -t thrift_file.thrift -h localhost -p 8010 -s ServiceName
     $ # Launching into ipython
     >>> client.api(*args)


### PR DESCRIPTION
Usage: thriftpy-cli [OPTIONS]

Error: Missing option "-t" / "--thrift".